### PR TITLE
Optimization using Montgomery's batch inversion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,11 +589,11 @@ fn check_evals_consistency(
     //   >= 1 - 1/2^128 because gemini_r is the 128 lower-significance bits output by Keccak256
     batch_inversion(&mut denominators);
 
-    let mut challenge_poly_eval = denominators
+    let mut challenge_poly_eval: Fr = denominators
         .iter()
         .zip(challenge_poly_lagrange)
         .map(|(ai, bi)| *ai * bi)
-        .fold(Fr::ZERO, |acc, x| acc + x);
+        .sum();
 
     let numerator = vanishing_poly_eval
         * Fr::from(SUBGROUP_SIZE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,13 +573,12 @@ fn check_evals_consistency(
         }
     }
 
-    let mut denominators = Vec::with_capacity(SUBGROUP_SIZE as usize);
     let mut root_power = Fr::ONE;
-
-    for _ in 0..SUBGROUP_SIZE {
-        denominators.push(root_power * gemini_r - Fr::ONE);
+    let mut denominators: [_; SUBGROUP_SIZE as usize] = core::array::from_fn(|_| {
+        let result = root_power * gemini_r - Fr::ONE;
         root_power *= SUBGROUP_GENERATOR_INVERSE;
-    }
+        result
+    });
 
     // For each i, we have:
     // Pr[SUBGROUP_GENERATOR_INVERSE^i * gemini_r - 1 is invertible]


### PR DESCRIPTION
This PR rewrites a certain computation in order to make use of Montgomery's batch inversion trick. This reduces the amount of scalar field element inversions from 256 to just 1. Asymptotically, this is a fixed amount of inversions. Concretely, for our current benchmarks, this optimization should incur an estimated speedup of ~34.58% to `verify_proof`.