### PR TITLE
Dimitris/add log derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ZKV_PUBS_HEX_FILE_PATH="${OUTPUT_DIR_PATH}/zkv_pubs.hex"
 # Get bb version and format it (e.g., 3.0.3 -> V3_0)
 BB_VERSION_FULL=$(bb --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 # Extract major and minor, then join with underscore
-BB_VERSION_KEY=$(echo "$BB_VERSION_FULL" | awk -F. '{print "V" $1 "_" $2}')
+BB_VERSION_KEY=$(echo "${BB_VERSION_FULL}" | awk -F. '{print "V" $1 "_" $2}')
 
 # Convert proof to valid JSON
 if [ -f "${PROOF_FILE_PATH}" ]; then
@@ -85,21 +85,21 @@ fi
 
 # Convert vk to hexadecimal format
 {
-  if [ -f "$VK_FILE_PATH" ]; then
-    printf "\"0x%s\"\n" "$(xxd -p -c 0 "$VK_FILE_PATH")" > "$ZKV_VK_HEX_FILE_PATH"
+  if [ -f "${VK_FILE_PATH}" ]; then
+    printf "\"0x%s\"\n" "$(xxd -p -c 0 "${VK_FILE_PATH}")" > "${ZKV_VK_HEX_FILE_PATH}"
     echo "✅ 'vk' hex file generated at ${ZKV_VK_HEX_FILE_PATH}."
   else
-    echo "❌ Error: Verification key file '$VK_FILE_PATH' not found. Skipping." >&2
+    echo "❌ Error: Verification key file '${VK_FILE_PATH}' not found. Skipping." >&2
   fi
 }
 
 # Convert public inputs to hexadecimal format
 {
-  if [ -f "$PUBS_FILE_PATH" ]; then
-    xxd -p -c 32 "$PUBS_FILE_PATH" | sed 's/.*/"0x&"/' | paste -sd, - | sed 's/.*/[&]/' > "$ZKV_PUBS_HEX_FILE_PATH"
+  if [ -f "${PUBS_FILE_PATH}" ]; then
+    xxd -p -c 32 "${PUBS_FILE_PATH}" | sed 's/.*/"0x&"/' | paste -sd, - | sed 's/.*/[&]/' > "${ZKV_PUBS_HEX_FILE_PATH}"
     echo "✅ 'pubs' hex file generated at ${ZKV_PUBS_HEX_FILE_PATH}."
   else
-    echo "❌ Error: Public inputs file '$PUBS_FILE_PATH' not found. Skipping." >&2
+    echo "❌ Error: Public inputs file '${PUBS_FILE_PATH}' not found. Skipping." >&2
   fi
 }
 ```

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -70,6 +70,8 @@ impl ProofType {
     ///
     /// Since the proof length is a linear function of `log_n` for both ZK and Plain
     /// proofs, this computes the inverse to recover `log_n`.
+    /// It is important to note that this does not guarantee that the derived `log_n`
+    /// value matches the actual value of `log_n` in the vk.
     pub fn log_n(&self) -> Result<u64, ProofError> {
         let byte_len = match self {
             ProofType::ZK(b) | ProofType::Plain(b) => b.len(),


### PR DESCRIPTION
This PR simply adds functionality for deriving the value of `log_n` from the proof length. This aims to enable zkVerify to charge more fairly (i.e., based on the value of `log_n`, instead of always using the maximum value of `log_n`).